### PR TITLE
Add Audio <> Video chapters sync + "Transcript Only" toggle

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: flask --app web.py --debug run
-worker: celery -A tasks worker --loglevel=INFO
+web: flask --app web.py --debug run -p 3000
+worker: celery -A tasks worker --loglevel=INFO -E -n smol_podcaster@%h

--- a/smol_podcaster.py
+++ b/smol_podcaster.py
@@ -272,7 +272,7 @@ def update_video_chapters(audio_chapters, audio_transcript, video_transcript):
 
     return "\n".join(updated_chapters)
     
-def main(url, name, speakers_count, transcript_only, video_only): 
+def main(url, name, speakers_count, transcript_only): 
     raw_transcript_path = f"./podcasts-raw-transcripts/{name}.json"
     clean_transcript_path = f"./podcasts-clean-transcripts/{name}.md"
     results_file_path = f"./podcasts-results/{name}.md"

--- a/smol_podcaster.py
+++ b/smol_podcaster.py
@@ -297,7 +297,7 @@ def update_video_chapters(audio_chapters, audio_file_name, video_file_name):
     return spaced
     
 
-def main(url, name, speakers_count, transcript_only): 
+def main(url, name, speakers_count, transcript_only, generate_extra): 
     raw_transcript_path = f"./podcasts-raw-transcripts/{name}.json"
     clean_transcript_path = f"./podcasts-clean-transcripts/{name}.md"
     results_file_path = f"./podcasts-results/{name}.md"
@@ -349,14 +349,14 @@ def main(url, name, speakers_count, transcript_only):
     
     print("Writeup is ready")
     
-    #title_suggestions_str = title_suggestions(writeup)
+    if generate_extra:
+        title_suggestions_str = title_suggestions(writeup)
     
-    #print("Titles are ready")
-    
-    # These tweets are never quite good... 
-    #tweet_suggestions_str = "" # tweet_suggestions(transcript)
-    
-    #print("Tweets are ready")
+        print("Titles are ready")
+        
+        tweet_suggestions_str = tweet_suggestions(transcript)
+        
+        print("Tweets are ready")
 
     with open(results_file_path, "w") as f:
         f.write("Chapters:\n")
@@ -368,12 +368,14 @@ def main(url, name, speakers_count, transcript_only):
         f.write("Show Notes:\n")
         f.write(show_notes)
         f.write("\n\n")
-        #f.write("Title Suggestions:\n")
-        #f.write(title_suggestions_str)
-        #f.write("\n\n")
-        #f.write("Tweet Suggestions:\n")
-        #f.write(tweet_suggestions_str)
-        #f.write("\n")
+        
+        if generate_extra:
+            f.write("Title Suggestions:\n")
+            f.write(title_suggestions_str)
+            f.write("\n\n")
+            f.write("Tweet Suggestions:\n")
+            f.write(tweet_suggestions_str)
+            f.write("\n")
         
     with open(substack_file_path, "w") as f:
         f.write("### Show Notes\n")
@@ -401,13 +403,14 @@ if __name__ == "__main__":
     parser.add_argument("name", help="The name of the output transcript file without extension.")
     parser.add_argument("speakers", help="The number of speakers on the track.", default=3)
     parser.add_argument("--transcript_only", help="Whether to only generate the transcript.", default=False, nargs='?')
-    parser.add_argument("--video_only", help="Only return the video chapters.", default=False, nargs='?')
+    parser.add_argument("--generate_extra", help="Whether to generate extra content like titles and tweets.", default=False, nargs='?')
     args = parser.parse_args()
 
     url = args.url
     name = args.name
     speakers_count = int(args.speakers)
     transcript_only = args.transcript_only
+    generate_extra = args.generate_extra
     
-    main(url, name, speakers_count, transcript_only)
+    main(url, name, speakers_count, transcript_only, generate_extra)
 

--- a/smol_podcaster.py
+++ b/smol_podcaster.py
@@ -6,7 +6,6 @@ import Levenshtein
 from dotenv import load_dotenv
 import os
 import re
-from datetime import datetime, timedelta
 import json
 
 import replicate
@@ -19,7 +18,7 @@ client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 anthropic = Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
 
 ANTHROPIC_MODEL = os.environ.get("ANTHROPIC_MODEL") or "claude-3-opus-20240229"
-GPT_MODEL = os.environ.get("GPT_MODEL") or "gpt-4o"
+GPT_MODEL = os.environ.get("GPT_MODEL") or "gpt-4-0125-preview"
 
 # common ML words that the replicate model doesn't know, can programatically update the transcript
 fix_recording_mapping = {
@@ -384,6 +383,11 @@ def main(url, name, speakers_count, transcript_only):
         f.write(chapters)
         f.write("\n\n")
         f.write("### Transcript\n")
+        
+        # This is a fair compromise between open source usability while being the easiest for me, sorry reader
+        if "Alessio" in transcript:
+            f.write("**Alessio** [00:00:00]: Hey everyone, welcome to the Latent Space podcast. This is Alessio, partner and CTO-in-Residence at [Decibel Partners](https://decibel.vc), and I'm joined by my co-host Swyx, founder of [Smol AI](https://smol.ai).")
+        
         f.write(transcript)
     
     print(f"Results written to {results_file_path}")

--- a/tasks.py
+++ b/tasks.py
@@ -9,9 +9,9 @@ app = Celery('tasks')
 app.config_from_object('celeryconfig')
 
 @app.task
-def run_smol_podcaster(url, name, speakers, transcript_only):
+def run_smol_podcaster(url, name, speakers, transcript_only, generate_extra):
     logger.info(f"Running smol_podcaster for {name}")
-    results = smol_podcaster.main(url, name, speakers, transcript_only)
+    results = smol_podcaster.main(url, name, speakers, transcript_only, generate_extra)
     
     logger.info(f"Results for {name}: {results}")
     return "The path was: " + results

--- a/tasks.py
+++ b/tasks.py
@@ -5,7 +5,7 @@ app = Celery('tasks')
 app.config_from_object('celeryconfig')
 
 @app.task
-def run_smol_podcaster(url, name, speakers, transcript_only, video_only):
-    results = smol_podcaster.main(url, name, speakers, transcript_only, video_only)
+def run_smol_podcaster(url, name, speakers, transcript_only):
+    results = smol_podcaster.main(url, name, speakers, transcript_only)
     
     return "The path was: " + results

--- a/tasks.py
+++ b/tasks.py
@@ -5,7 +5,7 @@ app = Celery('tasks')
 app.config_from_object('celeryconfig')
 
 @app.task
-def run_smol_podcaster(url, name, speakers):
-    results = smol_podcaster.main(url, name, speakers)
+def run_smol_podcaster(url, name, speakers, transcript_only, video_only):
+    results = smol_podcaster.main(url, name, speakers, transcript_only, video_only)
     
     return "The path was: " + results

--- a/tasks.py
+++ b/tasks.py
@@ -9,3 +9,9 @@ def run_smol_podcaster(url, name, speakers, transcript_only):
     results = smol_podcaster.main(url, name, speakers, transcript_only)
     
     return "The path was: " + results
+
+@app.task
+def run_video_chapters(video_name, audio_name, chapters):
+    results = smol_podcaster.update_video_chapters(video_name, audio_name, chapters)
+    
+    return "The path was: " + results

--- a/tasks.py
+++ b/tasks.py
@@ -1,17 +1,26 @@
+from celery.utils.log import get_task_logger
+
 from celery import Celery
 import smol_podcaster
+
+logger = get_task_logger(__name__)
 
 app = Celery('tasks')
 app.config_from_object('celeryconfig')
 
 @app.task
 def run_smol_podcaster(url, name, speakers, transcript_only):
+    logger.info(f"Running smol_podcaster for {name}")
     results = smol_podcaster.main(url, name, speakers, transcript_only)
     
+    logger.info(f"Results for {name}: {results}")
     return "The path was: " + results
 
 @app.task
-def run_video_chapters(video_name, audio_name, chapters):
-    results = smol_podcaster.update_video_chapters(video_name, audio_name, chapters)
+def run_video_chapters(chapters, audio_name, video_name):
+    logger.info(f"Updating video chapters for {audio_name}")
+    results = smol_podcaster.update_video_chapters(chapters, audio_name, video_name)
     
+    logger.info(f"Updated video chapters for {audio_name}: {results}")
     return "The path was: " + results
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,16 @@
         <input type="text" id="name" name="name" class="border p-2 w-full rounded">
       </div>
 
+      <div class="mb-4">
+        <label for="transcript-only" class="block text-gray-700 font-bold mb-2">Transcript Only?</label>
+        <input type="checkbox" id="transcript-only" name="transcript-only" class="border p-2 rounded">
+      </div>
+
+      <div class="mb-4">
+        <label for="video-only" class="block text-gray-700 font-bold mb-2">Video Only?</label>
+        <input type="checkbox" id="video-only" name="video-only" class="border p-2 rounded">
+      </div>
+
       <button class="bg-indigo-500 text-white py-2 px-4 rounded hover:bg-indigo-600">Submit</button>
 
     </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,11 +46,6 @@
         <input type="checkbox" id="transcript-only" name="transcript-only" class="border p-2 rounded">
       </div>
 
-      <div class="mb-4">
-        <label for="video-only" class="block text-gray-700 font-bold mb-2">Video Only?</label>
-        <input type="checkbox" id="video-only" name="video-only" class="border p-2 rounded">
-      </div>
-
       <button class="bg-indigo-500 text-white py-2 px-4 rounded hover:bg-indigo-600">Submit</button>
 
     </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,56 +1,99 @@
 <!DOCTYPE html>
 <html>
-
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script src="https://cdn.tailwindcss.com"></script>
-  <title>Smol Podcaster</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <title>Smol Podcaster</title>
 </head>
-
 <body class="bg-gray-100">
+    <header class="bg-indigo-600 p-4 text-white">
+        <h1 class="text-3xl font-bold text-center">Smol Podcaster</h1> 
+    </header>
 
-  <header class="bg-indigo-600 p-4 text-white">
-    <h1 class="text-3xl font-bold text-center">Smol Podcaster</h1> 
-  </header>
+    <main class="max-w-lg mx-auto p-6">
+        <div class="mb-6">
+            <div class="flex">
+                <div class="w-1/2 px-2">
+                    <button class="tab-button w-full py-2 px-4 bg-white text-indigo-600 font-semibold rounded-lg shadow-md hover:bg-gray-200 focus:outline-none active" data-tab="create-artifacts">Create Artifacts</button>
+                </div>
+                <div class="w-1/2 px-2">
+                    <button class="tab-button w-full py-2 px-4 bg-white text-indigo-600 font-semibold rounded-lg shadow-md hover:bg-gray-200 focus:outline-none" data-tab="sync-chapters">Sync Video Chapters</button>
+                </div>
+            </div>
+        </div>
 
-  <main class="max-w-lg mx-auto p-6">
+        <div id="create-artifacts" class="tab-content">
+            {% if confirmation %}
+            <div class="p-4 bg-green-200">
+                {{ confirmation }}
+            </div>
+            {% endif %}
 
-    <h2 class="text-2xl font-bold mb-6">Podcast Processing Form</h2>
+            <form action="/process" method="post" class="bg-white p-6 rounded-lg shadow-md">
+                <div class="mb-4">
+                    <label for="url" class="block text-gray-700 font-bold mb-2">URL:</label>
+                    <input type="text" id="url" name="url" class="border p-2 w-full rounded" required>
+                </div>
 
-    {% if confirmation %}
-      <div class="p-4 bg-green-200">
-        {{ confirmation }}
-      </div>
-    {% endif %}
-  
-    <form action="/process" method="post" class="bg-white p-6 rounded-lg shadow-md">
+                <div class="mb-4">
+                    <label for="speakers" class="block text-gray-700 font-bold mb-2">Number of Speakers:</label>
+                    <input type="number" id="speakers" name="speakers" class="border p-2 w-full rounded" required>
+                </div>
 
-      <div class="mb-4">
-        <label for="url" class="block text-gray-700 font-bold mb-2">URL:</label>
-        <input type="text" id="url" name="url" class="border p-2 w-full rounded">
-      </div>
+                <div class="mb-4">
+                    <label for="name" class="block text-gray-700 font-bold mb-2">Name:</label>
+                    <input type="text" id="name" name="name" class="border p-2 w-full rounded" required>
+                </div>
 
-      <div class="mb-4">
-        <label for="speakers" class="block text-gray-700 font-bold mb-2">Number of Speakers:</label>
-        <input type="text" id="speakers" name="speakers" class="border p-2 w-full rounded">
-      </div>
+                <div class="mb-4">
+                    <label for="transcript-only" class="block text-gray-700 font-bold mb-2">Transcript Only?</label>
+                    <input type="checkbox" id="transcript-only" name="transcript-only" class="border p-2 rounded">
+                </div>
 
-      <div class="mb-4">
-        <label for="name" class="block text-gray-700 font-bold mb-2">Name:</label>
-        <input type="text" id="name" name="name" class="border p-2 w-full rounded">
-      </div>
+                <button class="bg-indigo-500 text-white py-2 px-4 rounded hover:bg-indigo-600">Submit</button>
+            </form>
+        </div>
 
-      <div class="mb-4">
-        <label for="transcript-only" class="block text-gray-700 font-bold mb-2">Transcript Only?</label>
-        <input type="checkbox" id="transcript-only" name="transcript-only" class="border p-2 rounded">
-      </div>
+        <div id="sync-chapters" class="tab-content hidden">
+            <form action="/sync_chapters" method="post" class="bg-white p-6 rounded-lg shadow-md">
+                <div class="mb-4">
+                    <label for="video_name" class="block text-gray-700 font-bold mb-2">Video File Name:</label>
+                    <input type="text" id="video_name" name="video_name" class="border p-2 w-full rounded" required>
+                </div>
 
-      <button class="bg-indigo-500 text-white py-2 px-4 rounded hover:bg-indigo-600">Submit</button>
+                <div class="mb-4">
+                    <label for="audio_name" class="block text-gray-700 font-bold mb-2">Audio File Name:</label>
+                    <input type="text" id="audio_name" name="audio_name" class="border p-2 w-full rounded" required>
+                </div>
 
-    </form>
-  </main>
+                <div class="mb-4">
+                    <label for="chapters" class="block text-gray-700 font-bold mb-2">Chapters:</label>
+                    <textarea id="chapters" name="chapters" rows="10" class="border p-2 w-full rounded" required></textarea>
+                </div>
 
+                <button class="bg-indigo-500 text-white py-2 px-4 rounded hover:bg-indigo-600">Sync Chapters</button>
+            </form>
+        </div>
+    </main>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const tabButtons = document.querySelectorAll('.tab-button');
+            const tabContents = document.querySelectorAll('.tab-content');
+
+            tabButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    const tabId = this.getAttribute('data-tab');
+                    
+                    tabButtons.forEach(btn => btn.classList.remove('active'));
+                    tabContents.forEach(content => content.classList.add('hidden'));
+
+                    this.classList.add('active');
+                    document.getElementById(tabId).classList.remove('hidden');
+                });
+            });
+        });
+    </script>
 </body>
-
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,6 +51,11 @@
                     <input type="checkbox" id="transcript-only" name="transcript-only" class="border p-2 rounded">
                 </div>
 
+                <div class="mb-4">
+                    <label for="generate-extra" class="block text-gray-700 font-bold mb-2">Generate titles and tweets too?</label>
+                    <input type="checkbox" id="generate-extra" name="generate-extra" class="border p-2 rounded">
+                </div>
+
                 <button class="bg-indigo-500 text-white py-2 px-4 rounded hover:bg-indigo-600">Submit</button>
             </form>
         </div>

--- a/web.py
+++ b/web.py
@@ -19,12 +19,10 @@ def process_form():
     # Check if the checkboxes are checked, but transforming into bool because
     # the checkbox passes `on`, but blank is None
     transcript_only = True if request.form.get('transcript-only') else False
-    video_only = True if request.form.get('video-only') else False
     
     app.logger.info(f"Transcript Only: {transcript_only}")
-    app.logger.info(f"Video Only: {video_only}")
     
-    run_smol_podcaster.delay(url, name, speakers, transcript_only, video_only)
+    run_smol_podcaster.delay(url, name, speakers, transcript_only)
     
     return render_template('index.html', confirmation=(f"Now processing {name}"))
 

--- a/web.py
+++ b/web.py
@@ -32,10 +32,13 @@ def sync_chapters():
     audio_name = request.form.get('audio_name')
     chapters = request.form.get('chapters')
     
+    app.logger.info(f"Syncing chapters for {video_name} and {audio_name}")
     # Call the `update_video_chapters` function with the provided parameters
-    run_video_chapters.delay(video_name, audio_name, chapters)
+    task = run_video_chapters.delay(chapters, audio_name, video_name)
     
-    return render_template('index.html', confirmation=(f"Chapters synced for {video_name} and {audio_name}"))
+    app.logger.info(f"Task ID: {task.id}")
+    
+    return render_template('index.html', confirmation=(f"Syncing chapters for {video_name} and {audio_name}"))
 
 
 if __name__ == '__main__':

--- a/web.py
+++ b/web.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, render_template
-from tasks import run_smol_podcaster
+from tasks import run_smol_podcaster, run_video_chapters
 import logging
 
 app = Flask(__name__)
@@ -25,6 +25,18 @@ def process_form():
     run_smol_podcaster.delay(url, name, speakers, transcript_only)
     
     return render_template('index.html', confirmation=(f"Now processing {name}"))
+
+@app.route('/sync_chapters', methods=['POST'])
+def sync_chapters():
+    video_name = request.form.get('video_name')
+    audio_name = request.form.get('audio_name')
+    chapters = request.form.get('chapters')
+    
+    # Call the `update_video_chapters` function with the provided parameters
+    run_video_chapters.delay(video_name, audio_name, chapters)
+    
+    return render_template('index.html', confirmation=(f"Chapters synced for {video_name} and {audio_name}"))
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/web.py
+++ b/web.py
@@ -19,10 +19,11 @@ def process_form():
     # Check if the checkboxes are checked, but transforming into bool because
     # the checkbox passes `on`, but blank is None
     transcript_only = True if request.form.get('transcript-only') else False
+    generate_extra = True if request.form.get('generate-extra') else False
     
     app.logger.info(f"Transcript Only: {transcript_only}")
     
-    run_smol_podcaster.delay(url, name, speakers, transcript_only)
+    run_smol_podcaster.delay(url, name, speakers, transcript_only, generate_extra)
     
     return render_template('index.html', confirmation=(f"Now processing {name}"))
 

--- a/web.py
+++ b/web.py
@@ -1,7 +1,10 @@
 from flask import Flask, request, render_template
 from tasks import run_smol_podcaster
+import logging
 
 app = Flask(__name__)
+
+app.logger.setLevel(logging.INFO)
 
 @app.route('/')
 def index():
@@ -12,8 +15,16 @@ def process_form():
     url = request.form.get('url')
     speakers = int(request.form.get('speakers'))
     name = request.form.get('name')
-  
-    run_smol_podcaster.delay(url, name, speakers)
+    
+    # Check if the checkboxes are checked, but transforming into bool because
+    # the checkbox passes `on`, but blank is None
+    transcript_only = True if request.form.get('transcript-only') else False
+    video_only = True if request.form.get('video-only') else False
+    
+    app.logger.info(f"Transcript Only: {transcript_only}")
+    app.logger.info(f"Video Only: {video_only}")
+    
+    run_smol_podcaster.delay(url, name, speakers, transcript_only, video_only)
     
     return render_template('index.html', confirmation=(f"Now processing {name}"))
 


### PR DESCRIPTION
- Added a "Transcript Only" flag + toggle in the UI to skip generating all the notes. Saves a lot of tokens. I use it when generating video transcripts for YouTube chapters.
- Add a Video <> Audio chapters sync feature. If you use smol-podcaster to transcribe both your audio and video files, you can create chapters based on your audio ones, put them in the form, and create a new list that matches the video transcript for YouTube. Usually audio and video have different lengths because less pauses are edited, so re-using the audio timestamps in the video doesn't work. 
- Moved tweets / title generation beyond a flag; I never use them, so saving some tokens but people might want to do it anyway.